### PR TITLE
Move towards Container/Shell pattern "smart/dumb" components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,41 +6,49 @@ import {newList} from './factories';
 import ListsView from './components/ListsView';
 import ListView from './components/ListView';
 
-function App(props) {
-  const {
-    lists,
-    activeListId,
-    showCompleted,
-    addList,
-    updateList,
-    deleteList,
-    selectList,
-    toggleShowCompleted,
-  } = props;
+class App extends Component {
 
-  const list = _.find(lists, {id: activeListId});
+  componentDidMount() {
+    this.props.requestLists();
+  }
 
-  if (!list) return (
-    <ListsView
-      lists={lists}
-      selectList={selectList}
-      addList={() => addList({})}
-      />
-  );
+  render() {
+    const {
+      lists,
+      activeListId,
+      showCompleted,
+      addList,
+      updateList,
+      deleteList,
+      selectList,
+      toggleShowCompleted,
+    } = this.props;
 
-  return (
-    <ListView
-      list={list}
-      updateList={(data) => updateList(list.id, data)}
-      deleteList={() => {
+    const list = _.find(lists, {id: activeListId});
+
+    if (!list) return (
+      <ListsView
+        lists={lists}
+        selectList={selectList}
+        addList={() => addList({})}
+        />
+    );
+
+    return (
+      <ListView
+        list={list}
+        updateList={(data) => updateList(list.id, data)}
+        deleteList={() => {
           selectList();
           deleteList(list.id);
         }}
-      showCompleted={showCompleted}
-      toggleShowCompleted={toggleShowCompleted}
-      navigateBack={()=> selectList()}
-      />
-  )
+        showCompleted={showCompleted}
+        toggleShowCompleted={toggleShowCompleted}
+        navigateBack={()=> selectList()}
+        />
+    )
+  }
+
 }
 
 export default class AppContainer extends Component {
@@ -52,10 +60,6 @@ export default class AppContainer extends Component {
       lists: [],
       showCompleted: true,
     }
-  }
-
-  componentDidMount() {
-    this.requestLists();
   }
 
   selectList(listId) {
@@ -114,6 +118,7 @@ export default class AppContainer extends Component {
 
     return createElement(App, {
       lists,
+      requestLists: this.requestLists.bind(this),
       activeListId,
       showCompleted,
       addList: this.addList.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, createElement} from 'react';
 import _ from 'lodash';
 import * as apiClient from './http/apiClient';
 import {newList} from './factories';
@@ -6,7 +6,44 @@ import {newList} from './factories';
 import ListsView from './components/ListsView';
 import ListView from './components/ListView';
 
-export default class App extends Component {
+function App(props) {
+  const {
+    lists,
+    activeListId,
+    showCompleted,
+    addList,
+    updateList,
+    deleteList,
+    selectList,
+    toggleShowCompleted,
+  } = props;
+
+  const list = _.find(lists, {id: activeListId});
+
+  if (!list) return (
+    <ListsView
+      lists={lists}
+      selectList={selectList}
+      addList={() => addList({})}
+      />
+  );
+
+  return (
+    <ListView
+      list={list}
+      updateList={(data) => updateList(list.id, data)}
+      deleteList={() => {
+          selectList();
+          deleteList(list.id);
+        }}
+      showCompleted={showCompleted}
+      toggleShowCompleted={toggleShowCompleted}
+      navigateBack={()=> selectList()}
+      />
+  )
+}
+
+export default class AppContainer extends Component {
 
   constructor(props) {
     super(props);
@@ -75,26 +112,16 @@ export default class App extends Component {
 
     const list = _.find(lists, {id: activeListId});
 
-    if (!list) return (
-      <ListsView
-        lists={lists}
-        selectList={listId => this.selectList(listId)}
-        addList={() => this.addList()}
-        />
-    );
+    return createElement(App, {
+      lists,
+      activeListId,
+      showCompleted,
+      addList: this.addList.bind(this),
+      updateList: this.updateList.bind(this),
+      deleteList: this.deleteList.bind(this),
+      selectList: this.selectList.bind(this),
+      toggleShowCompleted: this.toggleShowCompleted.bind(this),
+    });
 
-    return (
-      <ListView
-        list={list}
-        updateList={(data) => this.updateList(list.id, data)}
-        deleteList={() => {
-          this.selectList();
-          this.deleteList(list.id);
-        }}
-        showCompleted={showCompleted}
-        toggleShowCompleted={() => this.toggleShowCompleted()}
-        navigateBack={listId => this.selectList()}
-        />
-    )
   }
 }


### PR DESCRIPTION
Proposed refactor for #2 

Isolate all of the "brains" into {App,ListView}Container and pass down simple props to the respective "shell" components

Makes use of "Containers" to house the brains and pass down simple props to the "shell" counterparts

See Container Components for an idea of "why" https://medium.com/@learnreact/container-components-c0e67432e005#.yu8f80cg7

This will also come in handy when it comes time to bring in Redux :)

"Containers" are serving to house/abstract state. Not to "eliminate all non stateless function components" 

Also
- Renames editingItems to drafts

_Note: Not yet moved towards binding in the constructor as I'm not 100% sold on sticking with ES6 class syntax yet (http://reactkungfu.com/2015/07/why-and-how-to-bind-methods-in-your-react-component-classes/)_
