### PR TITLE
Simplify state.*.drafts and related components

### DIFF
--- a/src/components/EditingText.js
+++ b/src/components/EditingText.js
@@ -1,36 +1,53 @@
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 
 const ESCAPE = 27;
 const ENTER = 13;
 
 export default class EditingText extends Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+  }
+
   componentDidMount() {
     this.focus();
   }
 
   focus() {
     const {value} = this.props;
-    this.refs.input.focus();
-    this.refs.input.setSelectionRange(value.length, value.length);
+    this._input.focus();
+    this._input.setSelectionRange(value.length, value.length);
   }
 
   handleKeyDown(event) {
-    const {value, cancel, save} = this.props;
-    if (event.which === ESCAPE) cancel();
-    if (event.which === ENTER) save(value);
+    const {props} = this;
+    if (event.which === ENTER) props.save(props.value);
+    if (event.which === ESCAPE) props.cancel();
+  }
+
+  handleChange({target: {value}}) {
+    this.props.onChange(value);
   }
 
   render() {
-    const {value, onChange} = this.props;
+    const {value} = this.props;
     return (
       <input
-        ref="input"
+        ref={(node) => this._input = node}
         type="text"
         value={value}
-        onChange={({target: {value}}) => onChange(value)}
-        onKeyDown={this.handleKeyDown.bind(this)}
+        onChange={this.handleChange}
+        onKeyDown={this.handleKeyDown}
         className="form-control input-md"
         />
     )
   }
 }
+
+EditingText.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  save: PropTypes.func.isRequired,
+  cancel: PropTypes.func.isRequired,
+};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, {Component} from 'react';
 import Icon from './Icon';
+import EditingText from './EditingText';
 
 export function ListsHeader() {
   return (
@@ -7,27 +8,28 @@ export function ListsHeader() {
   );
 }
 
-export function ListHeader({list, updateList, deleteList, navigateBack}) {
-  const {editing} = list;
+function ListHeaderShell(props) {
+  const {list, editing, toggleEditing, draft, updateDraft} = props;
   const navLeft = (
     <Icon
       icon={editing ? 'trash' : 'chevron-left'}
-      onClick={editing ? deleteList : navigateBack}
+      onClick={editing ? props.deleteList : props.navigateBack}
       />
   );
-  const navTitle = !editing ? list.title : (
-    <input
-      type="text"
-      className="form-control input-md"
-      value={list.title}
-      onChange={({target: {value}}) => updateList({title: value})}
-      autoFocus
+  const navTitle = !editing ? (
+    <span onDoubleClick={toggleEditing}>{list.title}</span>
+  ) : (
+    <EditingText
+      value={draft}
+      onChange={updateDraft}
+      save={() => props.updateList({title: draft})}
+      cancel={toggleEditing}
       />
   );
   const navRight = (
     <Icon
       icon={editing ? 'floppy-save' : 'pencil'}
-      onClick={() => updateList({editing: !editing})}
+      onClick={toggleEditing}
       style={{fontSize: 24, paddingRight: 15}}
       />
   );
@@ -35,6 +37,45 @@ export function ListHeader({list, updateList, deleteList, navigateBack}) {
   return (
     <Header left={navLeft} title={navTitle} right={navRight} />
   )
+}
+
+export class ListHeader extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      draft: props.list.title,
+      editing: false,
+    };
+    this.updateDraft = this.updateDraft.bind(this);
+    this.toggleEditing = this.toggleEditing.bind(this);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.list.title !== this.props.list.title) {
+      this.setState({editing: false});
+    }
+  }
+
+  toggleEditing() {
+    this.setState({editing: !this.state.editing});
+  }
+
+  updateDraft(draft) {
+    this.setState({draft});
+  }
+
+  render() {
+    return (
+      <ListHeaderShell
+        draft={this.state.draft}
+        updateDraft={this.updateDraft}
+        editing={this.state.editing}
+        toggleEditing={this.toggleEditing}
+        {...this.props}
+        />
+    );
+  }
 }
 
 function Header({left, title, right}) {

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -13,18 +13,14 @@ function ListItem(props) {
   const {completed} = item;
 
   const toggleCompleted = () => props.saveItem({completed: !completed});
-  const handleSave = (name) => {
-    props.saveItem({name});
-    props.toggleEditing();
-  };
 
   if (props.editing) return (
     <div className="list-group-item">
       <EditingText
-        value={props.draft.name}
-        onChange={name => props.updateDraft({name})}
-        cancel={props.cancelEdit}
-        save={handleSave}
+        value={props.draft}
+        onChange={props.updateDraft}
+        cancel={props.toggleEditing}
+        save={() => props.saveItem({name: props.draft})}
         />
     </div>
   );
@@ -53,10 +49,17 @@ class ListItemContainer extends Component {
 
   constructor(props) {
     super(props);
-    this.toggleEditing = this.toggleEditing.bind(this);
-    this.cancelEdit = this.cancelEdit.bind(this);
     this.state = {
       editing: false,
+      draft: props.item.name,
+    };
+    this.toggleEditing = this.toggleEditing.bind(this);
+    this.updateDraft = this.updateDraft.bind(this);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.item.name !== this.props.item.name) {
+      this.setState({editing: false});
     }
   }
 
@@ -64,16 +67,16 @@ class ListItemContainer extends Component {
     this.setState({editing: !this.state.editing});
   }
 
-  cancelEdit() {
-    this.toggleEditing();
-    this.props.updateDraft(this.props.item);
+  updateDraft(draft) {
+    this.setState({draft});
   }
 
   render() {
     const props = {
+      draft: this.state.draft,
+      updateDraft: this.updateDraft,
       editing: this.state.editing,
       toggleEditing: this.toggleEditing,
-      cancelEdit: this.cancelEdit,
       ...this.props,
     };
     return <ListItem {...props} />

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -1,5 +1,4 @@
 import React, {Component, createElement} from 'react';
-import _ from 'lodash';
 import * as apiClient from '../http/apiClient';
 import {newItem} from '../factories';
 import {ListHeader} from './Header';
@@ -15,26 +14,15 @@ const styles = {
   },
 };
 
-const DRAFT_ID = 'item.DRAFT';
-
 function ListView(props) {
   const {
     list,
     updateList,
     deleteList,
-    saveItem,
-    deleteItem,
-    addItem,
-    drafts,
-    updateDraft,
-    showCompleted,
-    toggleShowCompleted,
     navigateBack,
   } = props;
 
-  const getDraft = id => _.find(drafts, {id}) || {id};
-
-  const visibleItems = (showCompleted)
+  const visibleItems = (props.showCompleted)
     ? list.items
     : list.items.filter(item => !item.completed);
 
@@ -44,31 +32,28 @@ function ListView(props) {
 
       <div className="list-group">
         {visibleItems.map(item => {
-          const draft = {...item, ...getDraft(`item.${item.id}`)};
           return (
             <ListItem
               key={item.id}
               item={item}
-              saveItem={(data) => saveItem(item.id, data)}
-              deleteItem={() => deleteItem(item.id)}
-              draft={draft}
-              updateDraft={(data) => updateDraft(`item.${item.id}`, data)}
+              saveItem={(data) => props.saveItem(item.id, data)}
+              deleteItem={() => props.deleteItem(item.id)}
               />
           );
         })}
 
         <div className="list-group-item">
           <EditingText
-            value={getDraft(DRAFT_ID).name}
-            onChange={(name) => updateDraft(DRAFT_ID, {name})}
-            cancel={() => updateDraft(DRAFT_ID, {name: ''})}
-            save={(name) => addItem({name})}
+            value={props.itemDraft}
+            onChange={props.updateItemDraft}
+            save={() => props.addItem({name: props.itemDraft})}
+            cancel={() => props.updateItemDraft('')}
             />
         </div>
       </div>
 
-      <a onClick={toggleShowCompleted} style={styles.footerLink}>
-        {showCompleted ? 'hide' : 'show'} completed
+      <a onClick={props.toggleShowCompleted} style={styles.footerLink}>
+        {props.showCompleted ? 'hide' : 'show'} completed
       </a>
     </div>
   );
@@ -84,37 +69,33 @@ export default class ListViewContainer extends Component {
     super(props);
     this.state = {
       showCompleted: true,
-      drafts: [
-        {id: DRAFT_ID, name: ''}
-      ],
+      editingList: false,
+      itemDraft: '',
     };
 
     this.saveItem = this.saveItem.bind(this);
     this.deleteItem = this.deleteItem.bind(this);
     this.addItem = this.addItem.bind(this);
-    this.updateDraft = this.updateDraft.bind(this);
     this.toggleShowCompleted = this.toggleShowCompleted.bind(this);
+    this.toggleEditingList = this.toggleEditingList.bind(this);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.list.items.length > this.props.list.items.length) {
+      this.updateItemDraft('');
+    }
+  }
+
+  updateItemDraft(itemDraft) {
+    this.setState({itemDraft})
   }
 
   toggleShowCompleted() {
     this.setState({showCompleted: !this.state.showCompleted});
   }
 
-  // TODO: Consolidate/centralize this...
-  updateDraft(id, data) {
-    let {drafts} = this.state;
-    if (!_.find(drafts, {id})) {
-      drafts = drafts.concat([newItem({id})]);
-    }
-    drafts = drafts
-      .map(draft => (draft.id !== id) ? draft : {...draft, ...data});
-    this.setState({drafts});
-  }
-
-  clearDraft(id) {
-    const drafts = this.state.drafts
-      .filter(entry => entry.id !== id);
-    this.setState({drafts});
+  toggleEditingList() {
+    this.setState({editingList: !this.state.editingList});
   }
 
   addItem(data) {
@@ -124,7 +105,6 @@ export default class ListViewContainer extends Component {
         const item = res.body;
         const items = list.items.concat([item]);
         updateList({items});
-        this.clearDraft(DRAFT_ID);
       })
   }
 
@@ -146,22 +126,13 @@ export default class ListViewContainer extends Component {
             ? item
             : {...item, ...res.body}
           );
-        this.clearDraft(id);
         updateList({items});
       });
   }
 
   render() {
-    const {
-      showCompleted,
-      drafts,
-    } = this.state;
-    const {
-      list,
-      updateList,
-      deleteList,
-      navigateBack,
-    } = this.props;
+    const {showCompleted, editingList} = this.state;
+    const {list, updateList, deleteList, navigateBack} = this.props;
 
     // Rather than fiddling with JSX to pass down an object
     //  Example <ListView {...{list, updateList, /* ... */}} />
@@ -176,11 +147,13 @@ export default class ListViewContainer extends Component {
       saveItem: this.saveItem,
       deleteItem: this.deleteItem,
       addItem: this.addItem,
-      drafts,
-      updateDraft: this.updateDraft,
       showCompleted,
       toggleShowCompleted: this.toggleShowCompleted,
       navigateBack,
+      editingList,
+      toggleEditingList: this.toggleEditingList,
+      itemDraft: this.state.itemDraft,
+      updateItemDraft: this.updateItemDraft.bind(this),
     });
 
   }

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -1,4 +1,4 @@
-import React, {Component, createElement} from 'react';
+import React, {Component} from 'react';
 import * as apiClient from '../http/apiClient';
 import {newItem} from '../factories';
 import {ListHeader} from './Header';
@@ -132,30 +132,21 @@ export default class ListViewContainer extends Component {
 
   render() {
     const {showCompleted, editingList} = this.state;
-    const {list, updateList, deleteList, navigateBack} = this.props;
 
-    // Rather than fiddling with JSX to pass down an object
-    //  Example <ListView {...{list, updateList, /* ... */}} />
-    // or
-    //  Example <ListView list={list} updateList={updateList}, /* ... */}} />
-    // We can make use of the fact that the JSX de-sugars to createElement which accepts props as the 2nd argument
-    // See: https://facebook.github.io/react/docs/displaying-data.html#react-without-jsx
-    return createElement(ListView, {
-      list,
-      updateList,
-      deleteList,
+    const props = {
+      showCompleted,
+      toggleShowCompleted: this.toggleShowCompleted,
+      editingList,
+      toggleEditingList: this.toggleEditingList,
       saveItem: this.saveItem,
       deleteItem: this.deleteItem,
       addItem: this.addItem,
-      showCompleted,
-      toggleShowCompleted: this.toggleShowCompleted,
-      navigateBack,
-      editingList,
-      toggleEditingList: this.toggleEditingList,
       itemDraft: this.state.itemDraft,
       updateItemDraft: this.updateItemDraft.bind(this),
-    });
+      ...this.props,
+    };
 
+    return <ListView {...props} />;
   }
 
 }


### PR DESCRIPTION
**Refactor EditingText to maintain state.value and expose methods**
This is to gut the idea of managing a top level app.state.drafts. Much simpler/better IMO.
Also, state is not always the enemy. Sometimes avoiding it is :)

**Refactor concept of 'drafts' into oblivion. Also, ListHeader...**
Much simpler overall. Less dogmatic (avoid component state). More pragmatic (do what feels right).
- ListView and ListItem now make use of EditingText. No more ugly state.drafts!
- ListHeader now makes use of EditingText (only HTTP on "save")

~~**App.updateList now only HTTP for {title} not list operations**~~
_:memo: Cherry picked upstream_
Mostly a TEMP workaround to stop unneeded network requests.
Ideal solution: separate "updating state.lists" and "updating HTTP /lists" similar to how state/HTTP items is being handled

**Tone down props/state destructuring**
#### Visual Summary

This pretty well sums up the changes and new API for `<EditingText />`

![image](https://cloud.githubusercontent.com/assets/1240178/12411219/efadd0ee-be39-11e5-903b-e6c1afde5a81.png)
